### PR TITLE
Support Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
     ],
     "require": {
         "php" : "^8.2",
-        "illuminate/database": "^10.0|^11.0",
-        "illuminate/support": "^10.0|^11.0"
+        "illuminate/database": "^10.0|^11.0|^12.0",
+        "illuminate/support": "^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.6",
-        "orchestra/testbench": "^9.5",
+        "orchestra/testbench": "^9.5|^10.0",
         "phpunit/phpunit": "^11.0.1",
         "squizlabs/php_codesniffer": "^3.7"
     },


### PR DESCRIPTION
Adds Support for Laravel 12.

## Description

Allow illuminate/* packages in ^12.0 and allow orchestra/testbench:^10.0

## How has this been tested?

`composer run test`